### PR TITLE
add autotracking free scarecrow enabled

### DIFF
--- a/ootrando_overworldmap_hamsda/scripts/autotracking/auto_checks.lua
+++ b/ootrando_overworldmap_hamsda/scripts/autotracking/auto_checks.lua
@@ -94,6 +94,32 @@ local function updateDungeonPrizeFromDataAndFlags(data, code, flags)
   end
 end
 
+function updateScarecrow(segment)
+  if has('setting_racemode_on') or not AUTOTRACKER_ENABLE_ITEM_TRACKING then
+    return true
+  end
+
+  if not isInGame() then
+    return false
+  end
+
+  autotracker_debug("read scarecrow data", DBG_DETAIL)
+
+  local item = Tracker:FindObjectForCode("scarecrow")
+  if item then
+    local value = ReadU8(segment, 0x80400CBC)
+    local newSetting = (value ~= 0)
+    if item.Active ~= newSetting then
+      if newSetting then autotracker_debug(string.format("Y %s", item.Name))
+      else               autotracker_debug(string.format("N %s", item.Name))
+      end
+      item.Active = newSetting
+    end
+  else
+    autotracker_debug(string.format('Unable to find item by code: %s', 'scarecrow'), DBG_ERROR)
+  end
+end
+
 local function updateUsedKeysFromDataAndFlags(data, code, flags)
   local item = Tracker:FindObjectForCode(code)
   if item then

--- a/ootrando_overworldmap_hamsda/scripts/autotracking/autotracking.lua
+++ b/ootrando_overworldmap_hamsda/scripts/autotracking/autotracking.lua
@@ -29,12 +29,13 @@ print("---------------------------------------------------------------------")
 print("")
 
 -- Memory watches
-ScriptHost:AddMemoryWatch("OOT Magic Meter Data", 0x8011A602, 0x01, updateMagicMeterFromMemorySegment)
-ScriptHost:AddMemoryWatch("OOT Biggoron Data"   , 0x8011A60E, 0x01, updateBiggoronFromMemorySegment)
-ScriptHost:AddMemoryWatch("OOT Item Data 1"     , 0x8011A642, 0x1A, updateItems1FromMemorySegment)
-ScriptHost:AddMemoryWatch("OOT Item Data 2"     , 0x8011A66A, 0x4 , updateItems2FromMemorySegment)
-ScriptHost:AddMemoryWatch("OOT Quest Data"      , 0x8011A671, 0x12 , updateQuestFromMemorySegment)
-ScriptHost:AddMemoryWatch("OOT Key Data"        , 0x8011A68F, 0x13, updateKeysFromMemorySegment)
+ScriptHost:AddMemoryWatch("Rando FREE_SCARECROW_ENABLED"  , 0x80400CBC, 0x01, updateScarecrow)
+ScriptHost:AddMemoryWatch("OOT Magic Meter Data"          , 0x8011A602, 0x01, updateMagicMeterFromMemorySegment)
+ScriptHost:AddMemoryWatch("OOT Biggoron Data"             , 0x8011A60E, 0x01, updateBiggoronFromMemorySegment)
+ScriptHost:AddMemoryWatch("OOT Item Data 1"               , 0x8011A642, 0x1A, updateItems1FromMemorySegment)
+ScriptHost:AddMemoryWatch("OOT Item Data 2"               , 0x8011A66A, 0x4 , updateItems2FromMemorySegment)
+ScriptHost:AddMemoryWatch("OOT Quest Data"                , 0x8011A671, 0x12, updateQuestFromMemorySegment)
+ScriptHost:AddMemoryWatch("OOT Key Data"                  , 0x8011A68F, 0x13, updateKeysFromMemorySegment)
 
 ScriptHost:AddMemoryWatch("OOT Save Context Dungeons 1", 0x8011A6A4, 0x054, updateFromSaveContextDungeon1) -- 0x00, 0x01, 0x02
 ScriptHost:AddMemoryWatch("OOT Save Context Dungeons 2", 0x8011A6F8, 0x054, updateFromSaveContextDungeon2) -- 0x03, 0x04, 0x05


### PR DESCRIPTION
I added the ability to autotrack the setting free_scarecrow_enabled, which can be read from information provided by the randomizer team in 80400000 RANDO_CONTEXT. (contained in OoT-Randomizer/ASM/build/asm_symbols.txt)

FREE_SCARECROW_ENABLED uses address 80400CBC 